### PR TITLE
Add validation logic for zoom-meeting-webhook-handler

### DIFF
--- a/functions/zoom-meeting-webhook-handler/index.js
+++ b/functions/zoom-meeting-webhook-handler/index.js
@@ -11,21 +11,24 @@ const EVENT_MEETING_ENDED = 'meeting.ended';
 const EVENT_PARTICIPANT_JOINED = 'meeting.participant_joined';
 const EVENT_PARTICIPANT_LEFT = 'meeting.participant_left';
 
-const ZOOM_AUTH =
-  process.env.TEST_ZOOM_WEBHOOK_AUTH || process.env.ZOOM_WEBHOOK_AUTH;
-
 const ZOOM_SECRET =
   process.env.TEST_ZOOM_WEBHOOK_SECRET_TOKEN ||
   process.env.ZOOM_WEBHOOK_SECRET_TOKEN;
 
 const handler = async function (event, context) {
   try {
-    if (
-      !(
-        event.headers.authorization === ZOOM_AUTH ||
-        event.headers['x-zm-signature'] === ZOOM_AUTH
-      )
-    ) {
+    const message = `v0:${
+      event.headers['x-zm-request-timestamp']
+    }:${JSON.stringify(event.body)}`;
+
+    const hashForVerify = crypto
+      .createHmac('sha256', ZOOM_WEBHOOK_SECRET_TOKEN)
+      .update(message)
+      .digest('hex');
+
+    const signature = `v0=${hashForVerify}`;
+
+    if (request.headers['x-zm-signature'] !== signature) {
       console.log('Unauthorized', event);
       return {
         statusCode: 401,


### PR DESCRIPTION
This PR adds logic to respond to a zoom validation request with the appropriate response

Zoom requires Webhook validation for all webhooks created or modified after Oct 23, 2022 ([documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint)). The current webhook is presumably deployed before this date, so it's working fine without the validation logic (zoom will also send a revalidation request every 72 hours)

So in order for us to redeploy the zoom app, we would need to add this logic

## ‼️ Required

In order for this to work, we need to add the `ZOOM_WEBHOOK_SECRET_TOKEN` to the `.env` or netlify environment variables. This token can be found on the zoom app's page

## Context

This PR came about because we are trying to debug https://github.com/Virtual-Coffee/webhooks/issues/15

We actually don't need to merge this PR in order to debug that issue. Only if we look at the prod netlify logs and they look truly head-scratching, then we can look into redeploying the zoom app to see if that magically fixes the issue