### PR TITLE
Make zoom-meeting-webhook-handler `participant.joined` and `participant.left` retry logic into a background function

### DIFF
--- a/functions/handle-participant-joined-left-background/index.js
+++ b/functions/handle-participant-joined-left-background/index.js
@@ -1,22 +1,8 @@
 require('dotenv').config();
 
-const crypto = require('crypto');
-
-const { updateMeetingStatus, updateMeetingAttendence } = require('../zoom-meeting-webhook-handler/slack.js');
+const { updateMeetingAttendence } = require('../zoom-meeting-webhook-handler/slack.js');
 
 const rooms = require('../../data/rooms.json');
-
-const EVENT_MEETING_STARTED = 'meeting.started';
-const EVENT_MEETING_ENDED = 'meeting.ended';
-const EVENT_PARTICIPANT_JOINED = 'meeting.participant_joined';
-const EVENT_PARTICIPANT_LEFT = 'meeting.participant_left';
-
-const ZOOM_SECRET =
-  process.env.TEST_ZOOM_WEBHOOK_SECRET_TOKEN ||
-  process.env.ZOOM_WEBHOOK_SECRET_TOKEN;
-
-const ZOOM_AUTH =
-  process.env.TEST_ZOOM_WEBHOOK_AUTH || process.env.ZOOM_WEBHOOK_AUTH;
 
 const handler = async function (event, context) {
   try {

--- a/functions/handle-participant-joined-left-background/index.js
+++ b/functions/handle-participant-joined-left-background/index.js
@@ -1,0 +1,72 @@
+require('dotenv').config();
+
+const crypto = require('crypto');
+
+const { updateMeetingStatus, updateMeetingAttendence } = require('../zoom-meeting-webhook-handler/slack.js');
+
+const rooms = require('../../data/rooms.json');
+
+const EVENT_MEETING_STARTED = 'meeting.started';
+const EVENT_MEETING_ENDED = 'meeting.ended';
+const EVENT_PARTICIPANT_JOINED = 'meeting.participant_joined';
+const EVENT_PARTICIPANT_LEFT = 'meeting.participant_left';
+
+const ZOOM_SECRET =
+  process.env.TEST_ZOOM_WEBHOOK_SECRET_TOKEN ||
+  process.env.ZOOM_WEBHOOK_SECRET_TOKEN;
+
+const ZOOM_AUTH =
+  process.env.TEST_ZOOM_WEBHOOK_AUTH || process.env.ZOOM_WEBHOOK_AUTH;
+
+const handler = async function (event, context) {
+  try {
+    const request = JSON.parse(event.body);
+
+    // check our meeting ID. The meeting ID never changes, but the uuid is different for each instance
+
+    const room = rooms.find(
+      (room) => room.ZoomMeetingId === request.payload.object.id
+    );
+
+    if (room) {
+      const Airtable = require('airtable');
+      const base = new Airtable().base(process.env.AIRTABLE_COWORKING_BASE);
+
+      const { findRoomInstance } = require('../zoom-meeting-webhook-handler/airtable');
+
+          let roomInstance = await findRoomInstance(
+            room,
+            base,
+            request.payload.object.uuid
+          );
+
+          if (roomInstance) {
+            // create room event record
+            console.log(`found room instance ${roomInstance.getId()}`);
+
+            const updatedMeeting = await updateMeetingAttendence(
+              room,
+              roomInstance.get('slack_thread_timestamp'),
+              request
+            );
+          }
+    } else {
+      console.log('meeting ID is not co-working meeting');
+    }
+
+    return {
+      statusCode: 200,
+      body: '',
+    };
+  } catch (error) {
+    // output to netlify function log
+    console.log(error);
+    return {
+      statusCode: 500,
+      // Could be a custom message or object i.e. JSON.stringify(err)
+      body: JSON.stringify({ msg: error.message }),
+    };
+  }
+};
+
+module.exports = { handler };

--- a/functions/zoom-meeting-webhook-handler/index.js
+++ b/functions/zoom-meeting-webhook-handler/index.js
@@ -18,6 +18,8 @@ const ZOOM_SECRET =
 const ZOOM_AUTH =
   process.env.TEST_ZOOM_WEBHOOK_AUTH || process.env.ZOOM_WEBHOOK_AUTH;
 
+const APP_HOST = process.env.TEST_APP_HOST || process.env.APP_HOST;
+
 const handler = async function (event, context) {
   try {
     /**
@@ -96,22 +98,14 @@ const handler = async function (event, context) {
       switch (request.event) {
         case EVENT_PARTICIPANT_JOINED:
         case EVENT_PARTICIPANT_LEFT:
-          let roomInstance = await findRoomInstance(
-            room,
-            base,
-            request.payload.object.uuid
-          );
+          console.log('CALLING handle-participant-joined-left-background')
 
-          if (roomInstance) {
-            // create room event record
-            console.log(`found room instance ${roomInstance.getId()}`);
+          response = await fetch(`${APP_HOST}/handle-participant-joined-left-background`, {
+            method: 'POST',
+            body: event.body,
+          });
 
-            const updatedMeeting = await updateMeetingAttendence(
-              room,
-              roomInstance.get('slack_thread_timestamp'),
-              request
-            );
-          }
+          console.log('EXITING IMMEDIATELY FROM zoom-meeting-webhook-handler')
 
           break;
 

--- a/functions/zoom-meeting-webhook-handler/index.js
+++ b/functions/zoom-meeting-webhook-handler/index.js
@@ -105,6 +105,10 @@ const handler = async function (event, context) {
             body: event.body,
           });
 
+          if (!response.ok) {
+            throw new Error(`Error: ${response.status} ${response.statusText}`);
+          }
+
           console.log('EXITING IMMEDIATELY FROM zoom-meeting-webhook-handler')
 
           break;

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,3 +26,8 @@
   from = "/event-reminders"
   to = "/.netlify/functions/event-reminders-background"
   status = 200
+
+[[redirects]]
+  from = "/handle-participant-joined-left-background"
+  to = "/.netlify/functions/handle-participant-joined-left-background"
+  status = 200


### PR DESCRIPTION
Fixes https://github.com/Virtual-Coffee/webhooks/issues/15

This change makes it so we fire off a request to the participant joined/left retry logic in a background function then return immediately to zoom so zoom doesn't send a retry request 

Currently, we perform retry logic within the initial zoom request, which is ostensibly causing zoom to time out

As a note, I kept this PR as two separate commits because I like to have the first commit as close to a copy-paste with little changes as possible to put the retry logic into a background function in the git history. Then the next commit cleans it up a bit

## ‼️ VERIFY

I assume `APP_HOST` is set on prod, but I'm not 100% sure. We need to make sure it's set