### PR TITLE
Disable scheduled reminder crons ahead of Cloudflare migration

### DIFF
--- a/functions/event-reminders-daily/index.js
+++ b/functions/event-reminders-daily/index.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
-const { schedule } = require('@netlify/functions');
 var slackify = require('slackify-html');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
@@ -161,5 +160,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
+// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
 // module.exports.handler = schedule('0 12 * * *', handler);
 module.exports.handler = handler;

--- a/functions/event-reminders-daily/index.js
+++ b/functions/event-reminders-daily/index.js
@@ -3,6 +3,8 @@ const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
 var slackify = require('slackify-html');
+// Cron disabled (see export below) — import kept commented for re-enabling.
+// const { schedule } = require('@netlify/functions');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
   process.env.TEST_SLACK_ANNOUNCEMENTS_CHANNEL ||
@@ -160,6 +162,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
-// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
+// To re-enable, uncomment the schedule import above and the line below.
 // module.exports.handler = schedule('0 12 * * *', handler);
 module.exports.handler = handler;

--- a/functions/event-reminders-daily/index.js
+++ b/functions/event-reminders-daily/index.js
@@ -159,4 +159,7 @@ const handler = async function (event, context) {
   }
 };
 
-module.exports.handler = schedule('0 12 * * *', handler);
+// Cron disabled: reminders are moving to the new Cloudflare deployment.
+// Kept the schedule below for reference until the migration is complete.
+// module.exports.handler = schedule('0 12 * * *', handler);
+module.exports.handler = handler;

--- a/functions/event-reminders-hourly/index.js
+++ b/functions/event-reminders-hourly/index.js
@@ -3,6 +3,8 @@ const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
 var slackify = require('slackify-html');
+// Cron disabled (see export below) — import kept commented for re-enabling.
+// const { schedule } = require('@netlify/functions');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
   process.env.TEST_SLACK_ANNOUNCEMENTS_CHANNEL ||
@@ -286,6 +288,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
-// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
+// To re-enable, uncomment the schedule import above and the line below.
 // module.exports.handler = schedule('50 * * * *', handler);
 module.exports.handler = handler;

--- a/functions/event-reminders-hourly/index.js
+++ b/functions/event-reminders-hourly/index.js
@@ -3,7 +3,6 @@ const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
 var slackify = require('slackify-html');
-const { schedule } = require('@netlify/functions');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
   process.env.TEST_SLACK_ANNOUNCEMENTS_CHANNEL ||
@@ -287,5 +286,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
+// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
 // module.exports.handler = schedule('50 * * * *', handler);
 module.exports.handler = handler;

--- a/functions/event-reminders-hourly/index.js
+++ b/functions/event-reminders-hourly/index.js
@@ -285,4 +285,7 @@ const handler = async function (event, context) {
   }
 };
 
-module.exports.handler = schedule('50 * * * *', handler);
+// Cron disabled: reminders are moving to the new Cloudflare deployment.
+// Kept the schedule below for reference until the migration is complete.
+// module.exports.handler = schedule('50 * * * *', handler);
+module.exports.handler = handler;

--- a/functions/event-reminders-weekly/index.js
+++ b/functions/event-reminders-weekly/index.js
@@ -150,4 +150,7 @@ const handler = async function (event, context) {
   }
 };
 
-module.exports.handler = schedule('0 12 * * 1', handler);
+// Cron disabled: reminders are moving to the new Cloudflare deployment.
+// Kept the schedule below for reference until the migration is complete.
+// module.exports.handler = schedule('0 12 * * 1', handler);
+module.exports.handler = handler;

--- a/functions/event-reminders-weekly/index.js
+++ b/functions/event-reminders-weekly/index.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
-const { schedule } = require('@netlify/functions');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
   process.env.TEST_SLACK_ANNOUNCEMENTS_CHANNEL ||
@@ -152,5 +151,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
+// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
 // module.exports.handler = schedule('0 12 * * 1', handler);
 module.exports.handler = handler;

--- a/functions/event-reminders-weekly/index.js
+++ b/functions/event-reminders-weekly/index.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const { GraphQLClient, gql } = require('graphql-request');
 const { DateTime } = require('luxon');
 const { postMessage } = require('../../util/slack');
+// Cron disabled (see export below) — import kept commented for re-enabling.
+// const { schedule } = require('@netlify/functions');
 
 const SLACK_ANNOUNCEMENTS_CHANNEL =
   process.env.TEST_SLACK_ANNOUNCEMENTS_CHANNEL ||
@@ -151,6 +153,6 @@ const handler = async function (event, context) {
 
 // Cron disabled: reminders are moving to the new Cloudflare deployment.
 // Kept the schedule below for reference until the migration is complete.
-// To re-enable, restore `const { schedule } = require('@netlify/functions');` above.
+// To re-enable, uncomment the schedule import above and the line below.
 // module.exports.handler = schedule('0 12 * * 1', handler);
 module.exports.handler = handler;


### PR DESCRIPTION
### What

Comments out the Netlify `schedule()` registration in the three event-reminder functions so they no longer fire on cron:

- `functions/event-reminders-hourly/index.js` — was `50 * * * *`
- `functions/event-reminders-daily/index.js` — was `0 12 * * *`
- `functions/event-reminders-weekly/index.js` — was `0 12 * * 1`

Each now exports the bare handler, with the original cron expression kept commented for reference:

```js
// Cron disabled: reminders are moving to the new Cloudflare deployment.
// Kept the schedule below for reference until the migration is complete.
// module.exports.handler = schedule('50 * * * *', handler);
module.exports.handler = handler;
```

### Why

The bot is being redeployed to Cloudflare. With the Netlify deployment still live, its scheduled functions would keep firing and double-send Slack reminders once the Cloudflare version is running. Disabling the Netlify crons prevents the overlap.

### Notes

- The functions stay deployed and remain HTTP-invocable (e.g. via the existing `/event-reminders` redirect); only the cron trigger is removed.
- **Takes effect on the next Netlify deploy** — Netlify deregisters a function's schedule when the `schedule()` registration is gone.
- Fully reversible: uncomment the `schedule()` line and drop the bare export.