### PR TITLE
Disable Zoom webhook actions ahead of Cloudflare migration

### DIFF
--- a/functions/zoom-meeting-webhook-handler/index.js
+++ b/functions/zoom-meeting-webhook-handler/index.js
@@ -88,6 +88,13 @@ const handler = async function (event, context) {
     console.log(request.event);
 
     if (room) {
+      // DISABLED ahead of Cloudflare coworking-bot migration — endpoint still
+      // validates Zoom webhooks but performs no Slack/Airtable actions.
+      // The block below is intentionally commented out (not removed) so it can
+      // be restored or referenced. See branch `disable-actions`.
+      console.log('co-working meeting — actions disabled');
+
+      /*
       const Airtable = require('airtable');
       const base = new Airtable().base(process.env.AIRTABLE_COWORKING_BASE);
 
@@ -171,6 +178,7 @@ const handler = async function (event, context) {
         default:
           break;
       }
+      */
     } else {
       console.log('meeting ID is not co-working meeting');
     }


### PR DESCRIPTION
## Summary

The coworking bot has moved to Cloudflare, but Zoom is still sending webhooks to this legacy Netlify endpoint. This disables all side-effect actions in the `zoom-meeting-webhook-handler` while keeping the endpoint alive.

- Comments out (does not remove) the Slack/Airtable action block inside `if (room)` — covers `meeting.started`, `meeting.ended`, `meeting.participant_joined`, and `meeting.participant_left`.
- Signature verification, the `endpoint.url_validation` CRC challenge, and the `200` response are left intact, so Zoom keeps validating the endpoint and stops retrying.
- Adds a log line so incoming co-working events still show up in Netlify function logs.

## Verification

- `node --check functions/zoom-meeting-webhook-handler/index.js` passes.
- Validation/CRC path is untouched; handler still returns `200` with no Slack messages posted or Airtable records written.